### PR TITLE
Increase maximum zoom in viewer

### DIFF
--- a/src/Visualization.vue
+++ b/src/Visualization.vue
@@ -466,7 +466,7 @@ export default {
         initialZ *= wDims.height / wDims.width / 1.5
 
         this.zoom_min = maxDim / 2.
-        this.zoom_max = initialZ * 4
+        this.zoom_max = initialZ * 16
 
         this.camera.position.z = initialZ
       }


### PR DESCRIPTION
For simulations whose periodic bounding box is significantly larger than the protein, the maximum zoom is often insufficient to see anything more than a tiny blob with a bunch of ions floating around in the solvent. Increasing the maximum by four should suffice.